### PR TITLE
All three algorithms implemented chunk wise

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,17 +124,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
 
 [[package]]
-name = "md5"
-version = "0.7.0"
+name = "md-5"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "quick_hash"
 version = "0.1.0"
 dependencies = [
  "dialoguer",
- "md5",
+ "md-5",
+ "sha1",
  "sha2",
 ]
 
@@ -154,6 +158,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,5 @@ path = "src/main.rs"
 [dependencies]
 dialoguer = "0.10.2"
 sha2 = "0.10.6"
-md5 = "0.7.0"
+sha1 = "0.10.5"
+md-5 = "0.10.5"

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -1,16 +1,49 @@
-use md5;
-use sha2::{Digest, Sha256};
+use md5::Md5;
+use sha2::{Sha256, Digest};
+use sha1::Sha1;
+use std::io::{BufRead, BufReader};
+use std::fs::File;
 
 pub fn calc_sha256(filepath: &str) -> String {
-    let file_as_bytes = std::fs::read(filepath).unwrap();
-    let hash = Sha256::digest(file_as_bytes);
+
+    let file = File::open(filepath).unwrap();
+
+    let reader = BufReader::new(file);
+    let mut hasher = Sha256::new();
+    for l_result in reader.lines() {
+        hasher.update(l_result.unwrap().as_bytes());
+        hasher.update(b"\n");
+    }
+    let hash = hasher.finalize();
 
     format!("{:x}", hash)
 }
 
 pub fn calc_md5(filepath: &str) -> String {
-    let file_as_bytes = std::fs::read(filepath).unwrap();
-    let hash = md5::compute(file_as_bytes);
+    let file = File::open(filepath).unwrap();
+
+    let reader = BufReader::new(file);
+    let mut hasher = Md5::new();
+
+    for l_result in reader.lines() {
+        hasher.update(l_result.unwrap().as_bytes());
+    }
+
+    // acquire hash digest in the form of GenericArray,
+    // which in this case is equivalent to [u8; 16]
+    let result = hasher.finalize();
+    format!("{:x}", result)
+}
+
+pub fn calc_sha1(filepath: &str) -> String {
+    let file = File::open(filepath).unwrap();
+
+    let reader = BufReader::new(file);
+    let mut hasher = Sha1::new();
+    for l_result in reader.lines() {
+        hasher.update(l_result.unwrap().as_bytes());
+    }
+    let hash = hasher.finalize();
 
     format!("{:x}", hash)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ fn main() -> std::io::Result<()> {
     
 
     // The available hash algorithms
-    let hash_algorithms = vec!["SHA-256", "MD5"];
+    let hash_algorithms = vec!["SHA-256", "MD5", "SHA1"];
 
     // Makes a selection menu in the terminal with the available algs
     let selection = Select::with_theme(&ColorfulTheme::default())
@@ -60,6 +60,20 @@ fn main() -> std::io::Result<()> {
                 if check == 1 {
                     //println!("{:?}", checksum_str);
                     if algorithms::calc_md5(filepath) == checksum_str {
+                        println!("It's a match");
+                    }
+                    else{
+                        println!("It doesn't match");
+                    }
+                }
+            } else if hash_algorithms[index] == "SHA1" {
+                println!(
+                    "The SHA1 checksum for the file is: {}",
+                    algorithms::calc_sha1(filepath)
+                );
+                if check == 1 {
+                    //println!("{:?}", checksum_str);
+                    if algorithms::calc_sha1(filepath) == checksum_str {
                         println!("It's a match");
                     }
                     else{


### PR DESCRIPTION
SHA256, MD5 and SHA1

Outputs have changed since the previous commit because of chunking, but are consistent if you don't change versions.

I could fix that by reading fixed chunks instead of lines. Let me know if I need to do that.

@PhoenixFlame101 

Fixes #2 
PES2UG21CS477 Sanket Padhi